### PR TITLE
Add tests, tweak length/capacity types

### DIFF
--- a/tscache_poc.go
+++ b/tscache_poc.go
@@ -21,9 +21,15 @@ func (node *node) update(value interface{}, timestamp time.Time) {
 type Collection struct {
 	head     *node
 	tail     *node
-	length   uint64
-	capacity uint64
+	length   int
+	capacity int
 	mutex    sync.Mutex
+}
+
+func NewCollection(capacity int) *Collection {
+	return &Collection{
+		capacity: capacity,
+	}
 }
 
 //  Writes a node into a collection as the newest node(head.)
@@ -65,12 +71,12 @@ func (collection *Collection) Write(value interface{}, timestamp time.Time) {
 }
 
 // Length returns length of a Collection
-func (collection *Collection) Length() uint64 {
+func (collection *Collection) Length() int {
 	return collection.length
 }
 
 // Capacity returns the capacity of a Collection
-func (collection *Collection) Capacity() uint64 {
+func (collection *Collection) Capacity() int {
 	return collection.capacity
 }
 
@@ -79,10 +85,15 @@ func (collection *Collection) search(start, end time.Time) (ResultTail, ResultHe
 	collection.mutex.Lock()
 	defer collection.mutex.Unlock()
 
+	if collection.head == nil {
+		return
+	}
+
 	// Validation
 	if start.After(end) {
 		return
 	}
+
 	if start.After(collection.head.Time) {
 		return
 	}

--- a/tscache_test.go
+++ b/tscache_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+    "time"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+)
+
+func TestZeroLengthRead(t *testing.T) {
+    assert := require.New(t)
+
+    c := NewCollection(0)
+
+    head, tail, length := c.search(time.Unix(12, 0), time.Unix(20, 0))
+    assert.Nil(head)
+    assert.Nil(tail)
+    assert.Zero(length)
+}
+
+
+func TestOneLengthSearch(t *testing.T) {
+    assert := require.New(t)
+
+    c := NewCollection(1)
+    c.Write(3.14, time.Now())
+
+    head, tail, length := c.search(time.Unix(0, 0), time.Now())
+
+    assert.NotNil(head)
+    assert.NotNil(tail)
+    assert.Equal(int(1), int(length))
+}
+
+
+func TestManySearch(t *testing.T) {
+    assert := require.New(t)
+
+    c := NewCollection(5000)
+
+    for i := 0; i < c.Capacity(); i++ {
+        c.Write(i, time.Unix(int64(i), 0))
+    }
+
+    head, tail, length := c.search(time.Unix(0, 0), time.Now())
+
+    assert.NotNil(head)
+    assert.NotNil(tail)
+    assert.Equal(int(5000), int(length))
+}


### PR DESCRIPTION
- Added tests to validate `Collection.search` (requires `go get github.com/stretchr/testify`)
- Tweaked the Collection `length` and `capacity` fields to be ints, which makes working with literals easier.
- Added `NewCollection()` to spit out a new...Collection